### PR TITLE
make footer appear at the bottom of the page regardless of page content

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -42,9 +42,11 @@ export default function Layout(props) {
         }}
       />
 
-      <div className="antialiased text-gray-800 dark:bg-black dark:text-gray-400">
-        <Navbar {...props} />
-        <div>{children}</div>
+      <div className="antialiased text-gray-800 dark:bg-black dark:text-gray-400 flex flex-col min-h-screen">
+        <div className="grow">
+          <Navbar {...props} />
+          <div>{children}</div>
+        </div>
 
         <Footer {...props} />
       </div>


### PR DESCRIPTION
First of all, I want to thank you for this great project. 
What I noticed while I worked on this template is that once you have less content on your page, the footer while appear higher on the page.
As you may notice, the changes are minimal and won't break anything.
once again, I appreciate all the work you've done so far.

Best regards,
Mario